### PR TITLE
Edit .wallpaper

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -50,8 +50,11 @@ a {
     height: 100%;
     vertical-align: middle;
 }
+/* Use the full height of the new tab, instead of out of full image size, out of frame. */
 .wallpaper {
-    width: 100%;
+    height: 100vh;
+    margin: 0 auto;
+    display: block;
 }
 footer {
     position: fixed;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -50,7 +50,7 @@ a {
     height: 100%;
     vertical-align: middle;
 }
-/* Use the full height of the new tab, instead of out of full image size, out of frame. */
+/* Use the full height of the new tab, instead of always using the full image size, which can appear out of frame.*/
 .wallpaper {
     height: 100vh;
     margin: 0 auto;


### PR DESCRIPTION
**style.css**
- Use the full height of the new tab, instead of always using the full image size, which can appear out of frame.


Old size has a scroll bar on the new tab, and sometimes you're unable to see the entire image. In this new change to wallpaper CSS class, we utilize the full height of the browser.

Old Sizing
![old_size](https://user-images.githubusercontent.com/11654917/126426095-c2188599-a330-4a32-9b5b-7335eee98aa3.png)
New Sizing
![new_size](https://user-images.githubusercontent.com/11654917/126426097-8b2f34eb-3e1a-42ca-a60c-2220f3d8867b.png)
